### PR TITLE
Replace o3-mini with o4-mini model

### DIFF
--- a/OPENAI_AGENTS_FIXES.md
+++ b/OPENAI_AGENTS_FIXES.md
@@ -12,8 +12,9 @@ This document outlines the fixes implemented to ensure OpenAI agents work seamle
 ### 2. Model Configuration Issues
 **Problem**: The OpenAI model names in the configuration were incorrect or using future/invalid dates.
 **Fix**: Updated model configurations in `src/config.py`:
-- Changed `o3-deep-research-2025-06-26` to `o3-mini` (using available model)
-- Changed `o3-mini-2024-01-20` to `o3-mini` (corrected year and using available model)
+- Changed `o3-deep-research-2025-06-26` to `o4-mini` (using available model with high reasoning)
+- Changed `o3-mini-2024-01-20` to `o4-mini` (updated to use latest model with high reasoning)
+- Changed `o3-2024-12-17` to `o4-mini` (updated PRISMA configuration to use latest model)
 
 ### 3. Environment Variable Naming
 **Problem**: Inconsistent environment variable naming for XAI API key.
@@ -44,7 +45,8 @@ All system tests now pass successfully:
 - **All required dependencies**: ✅ Successfully installed
 
 ## Configuration Notes
-- The system now uses `o3-mini` model which is available as of January 31, 2025
+- The system now uses `o4-mini` model with high reasoning effort for all o3 tasks
+- All model configurations maintain high reasoning effort for optimal performance
 - Environment variables are properly validated
 - API key configuration is consistent across all services
 

--- a/PRISMA_FEATURE.md
+++ b/PRISMA_FEATURE.md
@@ -7,7 +7,7 @@ The PRISMA Systematic Review feature is a comprehensive multi-agent framework th
 ## 🌟 Key Features
 
 ### **Multi-Agent Architecture**
-- **O3 Deep Research**: Uses `o3-2024-12-17` with high reasoning effort for comprehensive analysis
+- **O4 Deep Research**: Uses `o4-mini` with high reasoning effort for comprehensive analysis
 - **Perplexity Deep Research**: Leverages `llama-3.1-sonar-large-128k-online` for literature search
 - **Grok Advanced Reasoning**: Employs `grok-beta` for critical analysis and bias detection
 - **Flowise Integration**: Connects to specialized chatflows for domain-specific knowledge
@@ -91,7 +91,7 @@ Workflow        Search         Quality         Review         Finalize
 
 ### AI Model Integration
 
-- **O3 High Reasoning** (`o3-2024-12-17`): Final review generation and synthesis
+- **O4 High Reasoning** (`o4-mini`): Final review generation and synthesis
 - **Perplexity Research** (`llama-3.1-sonar-large-128k-online`): Literature search and data extraction
 - **Grok Reasoning** (`grok-beta`): Critical analysis, bias detection, quality assessment
 - **Flowise Chatflows**: Specialized domain knowledge and additional research sources
@@ -157,7 +157,7 @@ A complete 8,000+ word systematic review including:
 ### PRISMA Configuration (`PRISMAConfig`)
 ```python
 # Model specifications
-O3_HIGH_REASONING = "o3-2024-12-17"         # Primary synthesis model
+O3_HIGH_REASONING = "o4-mini"               # Primary synthesis model
 PERPLEXITY_MODEL = "llama-3.1-sonar-large-128k-online"  # Research model
 GROK_MODEL = "grok-beta"                     # Reasoning model
 

--- a/src/config.py
+++ b/src/config.py
@@ -38,14 +38,14 @@ class OpenAIModelsConfig:
     
     # Enhanced OpenAI Models
     O3_DEEP_RESEARCH: ModelConfig = ModelConfig(
-        model_name="o3-mini",  # Use available o3-mini model
+        model_name="o4-mini",  # Use available o4-mini model with high reasoning
         max_tokens=8000,
         temperature=0.4,
         reasoning_effort="high"
     )
     
     O3_REASONING: ModelConfig = ModelConfig(
-        model_name="o3-mini",  # Use available o3-mini model
+        model_name="o4-mini",  # Use available o4-mini model with high reasoning
         max_tokens=4000,
         temperature=0.3,
         reasoning_effort="high"
@@ -76,7 +76,7 @@ class PRISMAConfig:
     
     # Required models and reasoning effort
     O3_HIGH_REASONING = ModelConfig(
-        model_name="o3-2024-12-17",
+        model_name="o4-mini",
         max_tokens=10000,
         temperature=0.3,
         reasoning_effort="high"


### PR DESCRIPTION
Replace `o3-mini` model with `o4-mini` to leverage enhanced reasoning capabilities for all relevant tasks.