### PR TITLE
Fix bugs in repository

### DIFF
--- a/src/flowise_client.py
+++ b/src/flowise_client.py
@@ -157,8 +157,23 @@ class FlowiseClient:
         """
         api_url = f"{self.base_url}/api/v1/prediction/{chatflow_id}"
         
-        # Use headers from configuration (handles Bearer prefix correctly)
-        headers = FlowiseConfig.get_headers()
+        # Use the *instance* API key when available so that callers can
+        # override the globally configured ``FLOWISE_API_KEY`` on a
+        # per-client basis (e.g. in unit tests or in multi-tenant
+        # scenarios).  Preserve the behaviour of
+        # ``FlowiseConfig.get_headers`` by automatically prepending the
+        # required *Bearer* prefix when it is missing.
+
+        if self.api_key.startswith("Bearer "):
+            headers = {
+                "Authorization": self.api_key,
+                "Content-Type": "application/json",
+            }
+        else:
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            }
         payload = {"question": question}
         
         # Add session ID if provided


### PR DESCRIPTION
Fix FlowiseClient.submit_job to use instance-level API key, enabling per-client authentication.

Previously, `FlowiseClient.submit_job` incorrectly used the global `FLOWISE_API_KEY` for authorization, ignoring any API key provided during client instantiation. This prevented per-instance credential usage and broke scenarios relying on it. This change ensures the method respects the `self.api_key`, aligning its behavior with the rest of the client's interface and allowing for flexible authentication.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a9f6d10e-89d0-4d5c-ac7b-fc8de10d976d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a9f6d10e-89d0-4d5c-ac7b-fc8de10d976d)