### PR TITLE
Implement markdown export for scientific publications

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -488,6 +488,25 @@ class EnhancedPromptEnhancerApp:
             return True
 
         # --------------------------------------------------
+        # Command handling for exports
+        # --------------------------------------------------
+        if stripped.lower() == "/export":
+            self.ui.export_latest_response()
+            return True
+        if stripped.lower() == "/save":
+            self.ui.export_full_conversation()
+            return True
+        if stripped.lower() == "/report":
+            self.ui.export_structured_report()
+            return True
+        if stripped.lower() == "/exports":
+            self.ui.list_exported_files()
+            return True
+        if stripped.lower() == "/publish":
+            self.ui.export_scientific_publication()
+            return True
+
+        # --------------------------------------------------
         # Primary processing path – log the user message and then try the
         # Flowise (or specialised) agent via
         # *agents.Runner*.  The external dependency is heavily mocked in the

--- a/src/ui/exporter.py
+++ b/src/ui/exporter.py
@@ -156,3 +156,60 @@ class ExportHandler:
 
         except Exception as e:
             self.console.print(f"❌ [red]Failed to list exports: {e}[/red]")
+
+    def export_scientific_publication(self) -> None:
+        """Export a journal-style scientific manuscript (IMRaD)."""
+        try:
+            if not self.app.messages:
+                self.console.print("⚠️ [yellow]No conversation to export. Ask a question first![/yellow]")
+                return
+            has_response = any(msg.get("role") == "assistant" for msg in self.app.messages)
+            if not has_response:
+                self.console.print("⚠️ [yellow]No AI response found to export.[/yellow]")
+                return
+
+            # Collect optional metadata
+            self.console.print("\n🧾 [cyan]Enter optional manuscript metadata (press Enter to skip)[/cyan]")
+            title = Prompt.ask("Title", default="", show_default=False)
+            authors = Prompt.ask("Authors (e.g., A. Author^1, B. Author^2*)", default="", show_default=False)
+            affiliations = Prompt.ask("Affiliations (use ^1 labels; multiline allowed)", default="", show_default=False)
+            corresponding = Prompt.ask("Corresponding author (name, email)", default="", show_default=False)
+            keywords = Prompt.ask("Keywords (comma-separated)", default="", show_default=False)
+            acknowledgments = Prompt.ask("Acknowledgments", default="", show_default=False)
+            funding = Prompt.ask("Funding", default="", show_default=False)
+            conflicts = Prompt.ask("Conflicts of interest", default="", show_default=False)
+            data_availability = Prompt.ask("Data availability statement", default="", show_default=False)
+            ethics = Prompt.ask("Ethics statement", default="", show_default=False)
+
+            meta = {
+                k: v.strip() for k, v in {
+                    "title": title,
+                    "authors": authors,
+                    "affiliations": affiliations,
+                    "corresponding": corresponding,
+                    "keywords": keywords,
+                    "acknowledgments": acknowledgments,
+                    "funding": funding,
+                    "conflicts": conflicts,
+                    "data_availability": data_availability,
+                    "ethics": ethics,
+                }.items() if v and v.strip()
+            }
+
+            file_path = self.app.markdown_exporter.export_scientific_publication(
+                self.app.messages,
+                self.app.current_mode,
+                manuscript_meta=meta or None,
+                verify_citations=False,
+            )
+
+            self.console.print()
+            self.console.print("📝 [green]Scientific manuscript export complete[/green]")
+            self.console.print(f"[bold]File:[/bold] `{file_path}`")
+            self.console.print(f"[bold]Location:[/bold] `{self.app.markdown_exporter.get_export_directory()}`")
+            self.console.print()
+            self.console.print("💡 Tip: Enable citation verification in code to auto-verify references.")
+            self.console.print()
+
+        except Exception as e:
+            self.console.print(f"❌ [red]Export failed: {e}[/red]")

--- a/src/ui/main_display.py
+++ b/src/ui/main_display.py
@@ -132,6 +132,7 @@ class UserInterface:
             ("/export", "Export latest response to markdown"),
             ("/save", "Export full conversation to markdown"),
             ("/report", "Export structured research report"),
+            ("/publish", "Export journal-style scientific manuscript (IMRaD)"),
             ("/exports", "List all exported files"),
             ("/jobs", "View the status of currently running jobs"),
             ("/archive", "View and download results from past jobs"),
@@ -350,6 +351,8 @@ class UserInterface:
         self.console.print("📄 /export - Save this response to markdown")
         self.console.print("📚 /save - Save full conversation to markdown")
         self.console.print("📊 /report - Create structured research report")
+        self.console.print("📝 /publish - Create journal-style IMRaD manuscript")
+        self.console.print("🗂️ /exports - List exported files")
         self.console.print()
 
     def display_jobs(self) -> None:
@@ -489,6 +492,9 @@ class UserInterface:
 
     def export_structured_report(self) -> None:
         self.exporter.export_structured_report()
+
+    def export_scientific_publication(self) -> None:
+        self.exporter.export_scientific_publication()
 
     def list_exported_files(self) -> None:
         self.exporter.list_exported_files()


### PR DESCRIPTION
Enable exporting content as a journal-style IMRaD scientific manuscript via a new `/publish` command.

---
<a href="https://cursor.com/background-agent?bcId=bc-71c71011-2b20-437a-bc92-64f54cd15d18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-71c71011-2b20-437a-bc92-64f54cd15d18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

